### PR TITLE
Neues URL-Schema BNetzA

### DIFF
--- a/freerfz_dl.py
+++ b/freerfz_dl.py
@@ -21,7 +21,7 @@ Lars Weiler
 '''
 Benötigt das Verzeichnis der zugeteilten deutschen Amateurfunkrufzeichen und
 ihrer Inhaber (Rufzeichenliste)
-http://www.bundesnetzagentur.de/SharedDocs/Downloads/DE/Sachgebiete/Telekommunikation/Unternehmen_Institutionen/Frequenzen/Amateurfunk/Rufzeichenliste/Rufzeichenliste_AFU.pdf?__blob=publicationFile&v=10
+https://data.bundesnetzagentur.de/Bundesnetzagentur/SharedDocs/Downloads/DE/Sachgebiete/Telekommunikation/Unternehmen_Institutionen/Frequenzen/Amateurfunk/Rufzeichenliste/rufzeichenliste_afu.pdf
 '''
 
 import os
@@ -76,7 +76,7 @@ class DLCalls:
 
 
     def download_Rufzeichenliste(self):
-        url = 'http://www.bundesnetzagentur.de/SharedDocs/Downloads/DE/Sachgebiete/Telekommunikation/Unternehmen_Institutionen/Frequenzen/Amateurfunk/Rufzeichenliste/Rufzeichenliste_AFU.pdf?__blob=publicationFile&v=11'
+        url = 'https://data.bundesnetzagentur.de/Bundesnetzagentur/SharedDocs/Downloads/DE/Sachgebiete/Telekommunikation/Unternehmen_Institutionen/Frequenzen/Amateurfunk/Rufzeichenliste/rufzeichenliste_afu.pdf'
         dl = False
 
         r = ur.urlopen(url)


### PR DESCRIPTION
Die BNetzA hat ihr URL-Schema geändert, damit das Script weiterhin funktioniert muss die neue URL hinterlegt werden.